### PR TITLE
Quick fixes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -67,8 +67,8 @@ local function isHerb(ref)
     return false
 end
 
-
 -- Update and serialize the reference's HerbalismSwitch.
+--- @param ref tes3reference
 local function updateHerbalismSwitch(ref, index)
     -- valid indices are: 0=default, 1=picked, 2=spoiled
 
@@ -77,6 +77,10 @@ local function updateHerbalismSwitch(ref, index)
 
     local switchNode = sceneNode:getObjectByName("HerbalismSwitch")
     if not switchNode then return end
+    if (switchNode.switchIndex == nil) then
+        mwse.log("Problematic mesh '%s': HerbalismSwitch is not of type NiSwitchNode.", ref.object.mesh)
+        return
+    end
 
     -- bounds check in case mesh does not implement a spoiled state
     index = math.min(index, #switchNode.children - 1)

--- a/main.lua
+++ b/main.lua
@@ -39,7 +39,7 @@ end
 
 -- Register the mod config menu (using bultin mwse.mcm).
 event.register("modConfigReady", function()
-    dofile("Data Files\\MWSE\\mods\\graphicHerbalism\\mcm.lua")
+    dofile("graphicHerbalism.mcm")
 end)
 
 

--- a/main.lua
+++ b/main.lua
@@ -204,24 +204,6 @@ local function getVisibleEffectsCount()
 end
 
 
--- Get the full display name of a magic effect, including attributes/skills.
-local function getEffectName(effect, stat)
-    local statName
-    if effect.targetsAttributes then
-        statName = tes3.findGMST(888 + stat).value
-    elseif effect.targetsSkills then
-        statName = tes3.findGMST(896 + stat).value
-    end
-
-    local effectName = tes3.findGMST(1283 + effect.id).value
-    if statName then
-        return effectName:match("%S+") .. " " .. statName
-    else
-        return effectName
-    end
-end
-
-
 -- Called when targeting a herb, adds ingredient information to the tooltip.
 local function onTooltipDrawn(e)
     local ref = e.reference
@@ -260,7 +242,6 @@ local function onTooltipDrawn(e)
 
         for i = 1, 4 do
             local effect = tes3.getMagicEffect(ingred.effects[i])
-            local target = math.max(ingred.effectAttributeIds[i], ingred.effectSkillIds[i])
 
             local block = parent:createBlock{id=GUI_ID[i]}
             block.autoHeight = true
@@ -276,7 +257,12 @@ local function onTooltipDrawn(e)
                 image.wrapText = false
                 image.borderLeft = 4
 
-                local label = block:createLabel{text=getEffectName(effect, target)}
+                local name = tes3.getMagicEffectName({
+                    effect = ingred.effects[i],
+                    attribute = ingred.effectAttributeIds[i],
+                    skill = ingred.effectSkillIds[i],
+                })
+                local label = block:createLabel{text=name}
                 label.wrapText = false
                 label.borderLeft = 4
             end


### PR DESCRIPTION
- Use `tes3.getMagicEffectName` instead of hardcoding from GMSTs.
- Report problematic meshes instead of erroring on them.